### PR TITLE
Fix for mappedpath

### DIFF
--- a/lib/installLiveCssFileWatcherInServer.js
+++ b/lib/installLiveCssFileWatcherInServer.js
@@ -118,7 +118,11 @@ module.exports = function (app, options, sio) {
                     });
                 }
 
-                var fileName = path.resolve(options.documentRoot, mappedPath.substr(1));
+                /* trim the leading slash, if it exist */
+                mappedPath = mappedPath[0] === '/' ? mappedPath.substr(1) : mappedPath;
+
+                var fileName = path.resolve(options.documentRoot, mappedPath);
+
                 if (fileName in clientsByFileName) {
                     clientsByFileName[fileName].push(client);
                 } else {


### PR DESCRIPTION
Jeg havde et problem, hvor livestyle altid ville fjerne det første char, når den lavede en mapped path. Dette resulterede i, at den forsøgte at servere, for eksempel siden, `/mappe/tyle/import.css` i stedet for `/mappe/style/import.css`.

Jeg løste problemet ved at teste for en '/' i starten af strengen, og kun cutte den væk i det tilfælde.
