### PR TITLE
Inject client before first script tag

### DIFF
--- a/lib/middleware/injectLiveStyleScriptIncludeIntoHtml.js
+++ b/lib/middleware/injectLiveStyleScriptIncludeIntoHtml.js
@@ -105,6 +105,8 @@ module.exports = function (config) {
                                 case 1: // <
                                     if (ch === '/') {
                                         state = 2;
+                                    } else if (ch === 's' || ch === 'S') {
+                                        state = 10;
                                     } else {
                                         state = 0;
                                     }
@@ -164,6 +166,42 @@ module.exports = function (config) {
                                 case 9: // </html
                                     if (ch === '>' || ch === ' ') {
                                         injectScriptAtIndex(chunk, i + 1 - '</html>'.length);
+                                        return;
+                                    } else {
+                                        state = 0;
+                                    }
+                                    break;
+                                case 10: // <s
+                                    if (ch === 'c' || ch === 'C') {
+                                        state = 11;
+                                    } else {
+                                        state = 0;
+                                    }
+                                    break;
+                                case 11: // <sc
+                                    if (ch === 'r' || ch === 'R') {
+                                        state = 12;
+                                    } else {
+                                        state = 0;
+                                    }
+                                    break;
+                                case 12: // <scr
+                                    if (ch === 'i' || ch === 'I') {
+                                        state = 13;
+                                    } else {
+                                        state = 0;
+                                    }
+                                    break;
+                                case 13: // <scri
+                                    if (ch === 'p' || ch === 'P') {
+                                        state = 14;
+                                    } else {
+                                        state = 0;
+                                    }
+                                    break;
+                                case 14: // <scrip
+                                    if (ch === 't' || ch === 'T') {
+                                        injectScriptAtIndex(chunk, i + 1 - '<script'.length);
                                         return;
                                     } else {
                                         state = 0;

--- a/test/proxy-test.js
+++ b/test/proxy-test.js
@@ -27,6 +27,25 @@ describe('livestyle server in proxy mode', function () {
         });
     });
     // create a livestyle server in pure proxy mode and an upstream
+    // server, then request an HTML file
+    // the HTML file should be patched with the bootstrapper right
+    // before </script>
+    it('should inject the livestyle client in a document before first script tag', function (done) {
+        var root = path.resolve(__dirname, 'proxy'),
+            upstreamApp = express().use(express['static'](root)),
+            upstreamServer = upstreamApp.listen(0),
+            upstreamServerUrl = 'http://127.0.0.1:' + upstreamServer.address().port + '/',
+            appInfo = createLiveStyleTestServer({
+                proxy: upstreamServerUrl
+            });
+
+        request({method: 'GET', url: 'http://127.0.0.1:' + appInfo.port + '/earlyscript.html'}, function (err, res, body) {
+            expect(err, 'to be null');
+            expect(body, 'to match', /<\/script><script id="earlyscript">/);
+            done();
+        });
+    });
+    // create a livestyle server in pure proxy mode and an upstream
     // server, then request an HTML file with no </head>
     // the HTML file should be patched with the bootstrapper right
     // before </html>

--- a/test/proxy/earlyscript.html
+++ b/test/proxy/earlyscript.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script id="earlyscript">'use strict'</script>
+    <meta charset="UTF-8">
+    <title>Document</title>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
When using RequireJS in a synchronously loaded script tag in `<head />` the requirejs script will expose AMD define before socket.io i loaded. It results in the [MISMATCHED ANONYMOUS DEFINE() MODULES](http://requirejs.org/docs/errors.html#mismatch) error because socket.io's AMD compatibility wrapper calls define itself.

This PR makes the livestyle client be injected before the first script tag if it comes before any of the other matches for `</head>` or `</html>`

Ping @papandreou @gustavnikolaj 