### PR TITLE
Node 8 compatibility: update socket.io dependency and test over newer versions of Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ node_js:
   - "0.10"
   - "0.12"
   - "iojs-v2.3.1"
+  - "4"
+  - "8"
 script: "npm run-script travis"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "morgan": "1.6.1",
     "optimist": "0.6.1",
     "request": "2.9.3",
-    "socket.io": "0.9.14",
-    "socket.io-client": "0.9.11"
+    "socket.io": "2.0.4",
+    "socket.io-client": "2.0.4"
   },
   "directories": {
     "bin": "./bin"


### PR DESCRIPTION
Hey guys, the current livestyle would crash no Node 8 (but work fine on Node 4), so I've updated the dependency, added extra Travis testing and verified on my local that everything checks out.